### PR TITLE
Fix Typo in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Unbound is a validating, recursive, and caching DNS resolver.
 ### Standard usage
 
 Pull this container:
-`docker pull mvance\unbound-rpi:latest`
+`docker pull mvance/unbound-rpi:latest`
 
 Run this container with the following command:
 


### PR DESCRIPTION
Just a little thing that tripped me up, while copying the command :)