### PR TITLE
⏳ Speedup Compile Time

### DIFF
--- a/1.10.0/Dockerfile
+++ b/1.10.0/Dockerfile
@@ -32,7 +32,7 @@ RUN set -e -x && \
       -DOPENSSL_NO_HEARTBEATS \
       -fstack-protector-strong && \
     make depend && \
-    make && \
+    nproc | xargs -I % make -j% && \
     make install_sw && \
     apt-get purge -y --auto-remove \
       $build_deps && \

--- a/1.10.1/Dockerfile
+++ b/1.10.1/Dockerfile
@@ -32,7 +32,7 @@ RUN set -e -x && \
       -DOPENSSL_NO_HEARTBEATS \
       -fstack-protector-strong && \
     make depend && \
-    make && \
+    nproc | xargs -I % make -j% && \
     make install_sw && \
     apt-get purge -y --auto-remove \
       $build_deps && \

--- a/1.11.0/Dockerfile
+++ b/1.11.0/Dockerfile
@@ -32,7 +32,7 @@ RUN set -e -x && \
       -DOPENSSL_NO_HEARTBEATS \
       -fstack-protector-strong && \
     make depend && \
-    make && \
+    nproc | xargs -I % make -j% && \
     make install_sw && \
     apt-get purge -y --auto-remove \
       $build_deps && \

--- a/1.12.0/Dockerfile
+++ b/1.12.0/Dockerfile
@@ -31,7 +31,7 @@ RUN set -e -x && \
       -DOPENSSL_NO_HEARTBEATS \
       -fstack-protector-strong && \
     make depend && \
-    make && \
+    nproc | xargs -I % make -j% && \
     make install_sw && \
     apt-get purge -y --auto-remove \
       $build_deps && \

--- a/1.13.0/Dockerfile
+++ b/1.13.0/Dockerfile
@@ -31,7 +31,7 @@ RUN set -e -x && \
       -DOPENSSL_NO_HEARTBEATS \
       -fstack-protector-strong && \
     make depend && \
-    make && \
+    nproc | xargs -I % make -j% && \
     make install_sw && \
     apt-get purge -y --auto-remove \
       $build_deps && \

--- a/1.13.1/Dockerfile
+++ b/1.13.1/Dockerfile
@@ -30,7 +30,7 @@ RUN set -e -x && \
       -DOPENSSL_NO_HEARTBEATS \
       -fstack-protector-strong && \
     make depend && \
-    make && \
+    nproc | xargs -I % make -j% && \
     make install_sw && \
     apt-get purge -y --auto-remove \
       $build_deps && \

--- a/1.13.2/Dockerfile
+++ b/1.13.2/Dockerfile
@@ -30,7 +30,7 @@ RUN set -e -x && \
       -DOPENSSL_NO_HEARTBEATS \
       -fstack-protector-strong && \
     make depend && \
-    make && \
+    nproc | xargs -I % make -j% && \
     make install_sw && \
     apt-get purge -y --auto-remove \
       $build_deps && \

--- a/1.14.0/Dockerfile
+++ b/1.14.0/Dockerfile
@@ -30,7 +30,7 @@ RUN set -e -x && \
       -DOPENSSL_NO_HEARTBEATS \
       -fstack-protector-strong && \
     make depend && \
-    make && \
+    nproc | xargs -I % make -j% && \
     make install_sw && \
     apt-get purge -y --auto-remove \
       $build_deps && \

--- a/1.15.0/Dockerfile
+++ b/1.15.0/Dockerfile
@@ -30,7 +30,7 @@ RUN set -e -x && \
       -DOPENSSL_NO_HEARTBEATS \
       -fstack-protector-strong && \
     make depend && \
-    make && \
+    nproc | xargs -I % make -j% && \
     make install_sw && \
     apt-get purge -y --auto-remove \
       $build_deps && \

--- a/1.16.0/Dockerfile
+++ b/1.16.0/Dockerfile
@@ -30,7 +30,7 @@ RUN set -e -x && \
       -DOPENSSL_NO_HEARTBEATS \
       -fstack-protector-strong && \
     make depend && \
-    make && \
+    nproc | xargs -I % make -j% && \
     make install_sw && \
     apt-get purge -y --auto-remove \
       $build_deps && \

--- a/1.9.1/Dockerfile
+++ b/1.9.1/Dockerfile
@@ -25,7 +25,7 @@ RUN set -e -x && \
     ./Configure linux-x32 && \
     ./config --prefix=/opt/openssl no-weak-ssl-ciphers no-ssl3 no-shared -DOPENSSL_NO_HEARTBEATS -fstack-protector-strong && \
     make depend && \
-    make && \
+    nproc | xargs -I % make -j% && \
     make install_sw && \
     apt-get purge -y --auto-remove \
       $build_deps && \

--- a/1.9.2/Dockerfile
+++ b/1.9.2/Dockerfile
@@ -25,7 +25,7 @@ RUN set -e -x && \
     ./Configure linux-x32 && \
     ./config --prefix=/opt/openssl no-weak-ssl-ciphers no-ssl3 no-shared -DOPENSSL_NO_HEARTBEATS -fstack-protector-strong && \
     make depend && \
-    make && \
+    nproc | xargs -I % make -j% && \
     make install_sw && \
     apt-get purge -y --auto-remove \
       $build_deps && \

--- a/1.9.3/Dockerfile
+++ b/1.9.3/Dockerfile
@@ -25,7 +25,7 @@ RUN set -e -x && \
     ./Configure linux-x32 && \
     ./config --prefix=/opt/openssl no-weak-ssl-ciphers no-ssl3 no-shared -DOPENSSL_NO_HEARTBEATS -fstack-protector-strong && \
     make depend && \
-    make && \
+    nproc | xargs -I % make -j% && \
     make install_sw && \
     apt-get purge -y --auto-remove \
       $build_deps && \

--- a/1.9.4/Dockerfile
+++ b/1.9.4/Dockerfile
@@ -25,7 +25,7 @@ RUN set -e -x && \
     ./Configure linux-x32 && \
     ./config --prefix=/opt/openssl no-weak-ssl-ciphers no-ssl3 no-shared -DOPENSSL_NO_HEARTBEATS -fstack-protector-strong && \
     make depend && \
-    make && \
+    nproc | xargs -I % make -j% && \
     make install_sw && \
     apt-get purge -y --auto-remove \
       $build_deps && \

--- a/1.9.5/Dockerfile
+++ b/1.9.5/Dockerfile
@@ -25,7 +25,7 @@ RUN set -e -x && \
     ./Configure linux-x32 && \
     ./config --prefix=/opt/openssl no-weak-ssl-ciphers no-ssl3 no-shared -DOPENSSL_NO_HEARTBEATS -fstack-protector-strong && \
     make depend && \
-    make && \
+    nproc | xargs -I % make -j% && \
     make install_sw && \
     apt-get purge -y --auto-remove \
       $build_deps && \

--- a/1.9.6/Dockerfile
+++ b/1.9.6/Dockerfile
@@ -25,7 +25,7 @@ RUN set -e -x && \
     ./Configure linux-x32 && \
     ./config --prefix=/opt/openssl no-weak-ssl-ciphers no-ssl3 no-shared -DOPENSSL_NO_HEARTBEATS -fstack-protector-strong && \
     make depend && \
-    make && \
+    nproc | xargs -I % make -j% && \
     make install_sw && \
     apt-get purge -y --auto-remove \
       $build_deps && \


### PR DESCRIPTION
Instead of using `make` we can use `nproc | xargs -I % make -j%` to use all available core in the system to speedup openssl compile time.