### PR TITLE
adds support for unbound v1.23.1 and updates openssl to v3.5.1

### DIFF
--- a/1.23.1/Dockerfile
+++ b/1.23.1/Dockerfile
@@ -1,0 +1,152 @@
+FROM debian:bullseye AS openssl
+
+ENV VERSION_OPENSSL=openssl-3.4.0 \
+    SHA256_OPENSSL=e15dda82fe2fe8139dc2ac21a36d4ca01d5313c75f99f46c4e8a27709b7294bf \
+    SOURCE_OPENSSL=https://www.openssl.org/source/ \
+    # OpenSSL OMC
+    OPGP_OPENSSL_1=EFC0A467D613CB83C7ED6D30D894E2CE8B3D79F5 \
+    # Richard Levitte
+    OPGP_OPENSSL_2=7953AC1FBC3DC8B3B292393ED5E9E43F7DF9EE8C \
+    # Matt Caswell
+    OPGP_OPENSSL_3=8657ABB260F056B1E5190839D9C4D26D0E604491 \
+    # Paul Dale
+    OPGP_OPENSSL_4=B7C1C14360F353A36862E4D5231C84CDDCC69C45 \
+    # Tomas Mraz
+    OPGP_OPENSSL_5=A21FAB74B0088AA361152586B8EF1A6BA9DA2D5C \
+    # Tim Hudson
+    OPGP_OPENSSL_6=C1F33DD8CE1D4CC613AF14DA9195C48241FBF7DD \
+    # Kurt Roeckx
+    OPGP_OPENSSL_7=E5E52560DD91C556DDBDA5D02064C53641C25E5D \
+    # OpenSSL
+    OPGP_OPENSSL_8=BA5473A2B0587B07FB27CF2D216094DFD0CB81EF
+
+WORKDIR /tmp/src
+
+RUN set -e -x && \
+    build_deps="build-essential ca-certificates curl dirmngr gnupg libidn2-0-dev libssl-dev" && \
+    DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y --no-install-recommends \
+      $build_deps && \
+    curl -L $SOURCE_OPENSSL$VERSION_OPENSSL.tar.gz -o openssl.tar.gz && \
+    echo "${SHA256_OPENSSL} ./openssl.tar.gz" | sha256sum -c - && \
+    curl -L $SOURCE_OPENSSL$VERSION_OPENSSL.tar.gz.asc -o openssl.tar.gz.asc && \
+    GNUPGHOME="$(mktemp -d)" && \
+    export GNUPGHOME && \
+    gpg --no-tty --keyserver keyserver.ubuntu.com --recv-keys "$OPGP_OPENSSL_1" "$OPGP_OPENSSL_2" "$OPGP_OPENSSL_3" "$OPGP_OPENSSL_4" "$OPGP_OPENSSL_5" "$OPGP_OPENSSL_6" "$OPGP_OPENSSL_7" "$OPGP_OPENSSL_8" && \
+    gpg --batch --verify openssl.tar.gz.asc openssl.tar.gz && \
+    tar xzf openssl.tar.gz && \
+    cd $VERSION_OPENSSL && \
+    ./Configure linux-x32 && \
+    ./config \
+      --prefix=/opt/openssl \
+      --openssldir=/opt/openssl \
+      no-weak-ssl-ciphers \
+      no-ssl3 \
+      no-shared \
+      -DOPENSSL_NO_HEARTBEATS \
+      -fstack-protector-strong && \
+    make depend && \
+    nproc | xargs -I % make -j% && \
+    make install_sw && \
+    apt-get purge -y --auto-remove \
+      $build_deps && \
+    rm -rf \
+        /tmp/* \
+        /var/tmp/* \
+        /var/lib/apt/lists/*
+
+FROM debian:bullseye AS unbound
+
+ENV NAME=unbound
+ENV UNBOUND_VERSION=1.23.1
+ENV UNBOUND_SHA256=6a6b117c799d8de3868643397e0fd71591f6d42f4473f598bdb22609ff362590
+ENV UNBOUND_DOWNLOAD_URL=https://nlnetlabs.nl/downloads/unbound/unbound-1.23.1.tar.gz
+
+WORKDIR /tmp/src
+
+COPY --from=openssl /opt/openssl /opt/openssl
+
+RUN build_deps="curl gcc libc-dev libevent-dev libexpat1-dev libnghttp2-dev make" && \
+    set -x && \
+    DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y --no-install-recommends \
+      $build_deps \
+      bsdmainutils \
+      ca-certificates \
+      ldnsutils \
+      libevent-2.1-7 \
+      libexpat1 && \
+    curl -sSL $UNBOUND_DOWNLOAD_URL -o unbound.tar.gz && \
+    echo "${UNBOUND_SHA256} *unbound.tar.gz" | sha256sum -c - && \
+    tar xzf unbound.tar.gz && \
+    rm -f unbound.tar.gz && \
+    cd unbound-1.23.1 && \
+    groupadd _unbound && \
+    useradd -g _unbound -s /etc -d /dev/null _unbound && \
+    ./configure \
+        --disable-dependency-tracking \
+        --prefix=/opt/unbound \
+        --with-pthreads \
+        --with-username=_unbound \
+        --with-ssl=/opt/openssl \
+        --with-libevent \
+        --with-libnghttp2 \
+        --enable-tfo-server \
+        --enable-tfo-client \
+        --enable-event-api && \
+    make install && \
+    mv /opt/unbound/etc/unbound/unbound.conf /opt/unbound/etc/unbound/unbound.conf.example && \
+    apt-get purge -y --auto-remove \
+      $build_deps && \
+    rm -rf \
+        /opt/unbound/share/man \
+        /tmp/* \
+        /var/tmp/* \
+        /var/lib/apt/lists/*
+
+FROM debian:bullseye
+
+WORKDIR /tmp/src
+
+COPY --from=unbound /opt /opt
+
+RUN set -x && \
+    DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y --no-install-recommends \
+      bsdmainutils \
+      ca-certificates \
+      ldnsutils \
+      libevent-2.1-7 \
+      libnghttp2-14 \
+      libexpat1 && \
+    groupadd _unbound && \
+    useradd -g _unbound -s /etc -d /dev/null _unbound && \
+    apt-get purge -y --auto-remove \
+      $build_deps && \
+    rm -rf \
+        /opt/unbound/share/man \
+        /tmp/* \
+        /var/tmp/* \
+        /var/lib/apt/lists/*
+
+COPY data/ /
+
+RUN chmod +x /unbound.sh
+
+WORKDIR /opt/unbound/
+
+ENV PATH="/opt/unbound/sbin:$PATH"
+
+ENV UNBOUND_VERSION=1.23.1
+
+LABEL org.opencontainers.image.version=${UNBOUND_VERSION} \
+      org.opencontainers.image.title="mvance/unbound-rpi" \
+      org.opencontainers.image.description="a validating, recursive, and caching DNS resolver" \
+      org.opencontainers.image.url="https://github.com/MatthewVance/unbound-docker-rpi" \
+      org.opencontainers.image.vendor="Matthew Vance" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.source="https://github.com/MatthewVance/unbound-docker-rpi"
+
+EXPOSE 53/tcp
+EXPOSE 53/udp
+
+HEALTHCHECK --interval=30s --timeout=30s --start-period=10s --retries=3 CMD drill @127.0.0.1 cloudflare.com || exit 1
+
+CMD ["/unbound.sh"]

--- a/1.23.1/Dockerfile
+++ b/1.23.1/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:bullseye AS openssl
 
-ENV VERSION_OPENSSL=openssl-3.4.0 \
-    SHA256_OPENSSL=e15dda82fe2fe8139dc2ac21a36d4ca01d5313c75f99f46c4e8a27709b7294bf \
+ENV VERSION_OPENSSL=openssl-3.5.1 \
+    SHA256_OPENSSL=529043b15cffa5f36077a4d0af83f3de399807181d607441d734196d889b641f \
     SOURCE_OPENSSL=https://www.openssl.org/source/ \
     # OpenSSL OMC
     OPGP_OPENSSL_1=EFC0A467D613CB83C7ED6D30D894E2CE8B3D79F5 \
@@ -35,7 +35,6 @@ RUN set -e -x && \
     gpg --batch --verify openssl.tar.gz.asc openssl.tar.gz && \
     tar xzf openssl.tar.gz && \
     cd $VERSION_OPENSSL && \
-    ./Configure linux-x32 && \
     ./config \
       --prefix=/opt/openssl \
       --openssldir=/opt/openssl \

--- a/1.23.1/data/opt/unbound/etc/unbound/a-records.conf
+++ b/1.23.1/data/opt/unbound/etc/unbound/a-records.conf
@@ -1,0 +1,5 @@
+# A Record
+    #local-data: "somecomputer.local. A 192.168.1.1"
+
+# PTR Record
+    #local-data-ptr: "192.168.1.1 somecomputer.local."

--- a/1.23.1/data/opt/unbound/etc/unbound/forward-records.conf
+++ b/1.23.1/data/opt/unbound/etc/unbound/forward-records.conf
@@ -1,0 +1,60 @@
+forward-zone:
+    # Forward all queries (except those in cache and local zone) to
+    # upstream recursive servers
+    name: "."
+    # Queries to this forward zone use TLS
+    forward-tls-upstream: yes
+
+    # https://dnsprivacy.org/wiki/display/DP/DNS+Privacy+Test+Servers
+
+    ## Cloudflare
+    forward-addr: 1.1.1.1@853#cloudflare-dns.com
+    forward-addr: 1.0.0.1@853#cloudflare-dns.com
+    #forward-addr: 2606:4700:4700::1111@853#cloudflare-dns.com
+    #forward-addr: 2606:4700:4700::1001@853#cloudflare-dns.com
+
+    ## Cloudflare Malware
+    # forward-addr: 1.1.1.2@853#security.cloudflare-dns.com
+    # forward-addr: 1.0.0.2@853#security.cloudflare-dns.com
+    # forward-addr: 2606:4700:4700::1112@853#security.cloudflare-dns.com
+    # forward-addr: 2606:4700:4700::1002@853#security.cloudflare-dns.com
+
+    ## Cloudflare Malware and Adult Content
+    # forward-addr: 1.1.1.3@853#family.cloudflare-dns.com
+    # forward-addr: 1.0.0.3@853#family.cloudflare-dns.com
+    # forward-addr: 2606:4700:4700::1113@853#family.cloudflare-dns.com
+    # forward-addr: 2606:4700:4700::1003@853#family.cloudflare-dns.com
+
+    ## CleanBrowsing Security Filter
+    # forward-addr: 185.228.168.9@853#security-filter-dns.cleanbrowsing.org
+    # forward-addr: 185.228.169.9@853#security-filter-dns.cleanbrowsing.org
+    # forward-addr: 2a0d:2a00:1::2@853#security-filter-dns.cleanbrowsing.org
+    # forward-addr: 2a0d:2a00:2::2@853#security-filter-dns.cleanbrowsing.org
+
+    ## CleanBrowsing Adult Filter
+    # forward-addr: 185.228.168.10@853#adult-filter-dns.cleanbrowsing.org
+    # forward-addr: 185.228.169.11@853#adult-filter-dns.cleanbrowsing.org
+    # forward-addr: 2a0d:2a00:1::1@853#adult-filter-dns.cleanbrowsing.org
+    # forward-addr: 2a0d:2a00:2::1@853#adult-filter-dns.cleanbrowsing.org
+
+    ## CleanBrowsing Family Filter
+    # forward-addr: 185.228.168.168@853#family-filter-dns.cleanbrowsing.org
+    # forward-addr: 185.228.169.168@853#family-filter-dns.cleanbrowsing.org
+    # forward-addr: 2a0d:2a00:1::@853#family-filter-dns.cleanbrowsing.org
+    # forward-addr: 2a0d:2a00:2::@853#family-filter-dns.cleanbrowsing.org
+
+    ## Quad9
+    # forward-addr: 9.9.9.9@853#dns.quad9.net
+    # forward-addr: 149.112.112.112@853#dns.quad9.net
+    # forward-addr: 2620:fe::fe@853#dns.quad9.net
+    # forward-addr: 2620:fe::9@853#dns.quad9.net
+
+    ## getdnsapi.net
+    # forward-addr: 185.49.141.37@853#getdnsapi.net
+    # forward-addr: 2a04:b900:0:100::37@853#getdnsapi.net
+
+    ## Surfnet
+    # forward-addr: 145.100.185.15@853#dnsovertls.sinodun.com
+    # forward-addr: 145.100.185.16@853#dnsovertls1.sinodun.com
+    # forward-addr: 2001:610:1:40ba:145:100:185:15@853#dnsovertls.sinodun.com
+    # forward-addr: 2001:610:1:40ba:145:100:185:16@853#dnsovertls1.sinodun.com

--- a/1.23.1/data/opt/unbound/etc/unbound/srv-records.conf
+++ b/1.23.1/data/opt/unbound/etc/unbound/srv-records.conf
@@ -1,0 +1,2 @@
+# SRV records
+# _service._proto.name. | TTL | class | SRV | priority | weight | port | target.

--- a/1.23.1/data/unbound.sh
+++ b/1.23.1/data/unbound.sh
@@ -1,0 +1,370 @@
+#!/bin/bash
+
+reserved=12582912
+availableMemory=$((1024 * $( (grep MemAvailable /proc/meminfo || grep MemTotal /proc/meminfo) | sed 's/[^0-9]//g' ) ))
+memoryLimit=$availableMemory
+[ -r /sys/fs/cgroup/memory/memory.limit_in_bytes ] && memoryLimit=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes | sed 's/[^0-9]//g')
+[[ ! -z $memoryLimit && $memoryLimit -gt 0 && $memoryLimit -lt $availableMemory ]] && availableMemory=$memoryLimit
+if [ $availableMemory -le $(($reserved * 2)) ]; then
+    echo "Not enough memory" >&2
+    exit 1
+fi
+availableMemory=$(($availableMemory - $reserved))
+rr_cache_size=$(($availableMemory / 3))
+# Use roughly twice as much rrset cache memory as msg cache memory
+msg_cache_size=$(($rr_cache_size / 2))
+nproc=$(nproc)
+export nproc
+if [ "$nproc" -gt 1 ]; then
+    threads=$((nproc - 1))
+    # Calculate base 2 log of the number of processors
+    nproc_log=$(perl -e 'printf "%5.5f\n", log($ENV{nproc})/log(2);')
+
+    # Round the logarithm to an integer
+    rounded_nproc_log="$(printf '%.*f\n' 0 "$nproc_log")"
+
+    # Set *-slabs to a power of 2 close to the num-threads value.
+    # This reduces lock contention.
+    slabs=$(( 2 ** rounded_nproc_log ))
+else
+    threads=1
+    slabs=4
+fi
+
+if [ ! -f /opt/unbound/etc/unbound/unbound.conf ]; then
+    sed \
+        -e "s/@MSG_CACHE_SIZE@/${msg_cache_size}/" \
+        -e "s/@RR_CACHE_SIZE@/${rr_cache_size}/" \
+        -e "s/@THREADS@/${threads}/" \
+        -e "s/@SLABS@/${slabs}/" \
+        > /opt/unbound/etc/unbound/unbound.conf << EOT
+server:
+    ###########################################################################
+    # BASIC SETTINGS
+    ###########################################################################
+    # Time to live maximum for RRsets and messages in the cache. If the maximum
+    # kicks in, responses to clients still get decrementing TTLs based on the
+    # original (larger) values. When the internal TTL expires, the cache item
+    # has expired. Can be set lower to force the resolver to query for data
+    # often, and not trust (very large) TTL values.
+    cache-max-ttl: 86400
+
+    # Time to live minimum for RRsets and messages in the cache. If the minimum
+    # kicks in, the data is cached for longer than the domain owner intended,
+    # and thus less queries are made to look up the data. Zero makes sure the
+    # data in the cache is as the domain owner intended, higher values,
+    # especially more than an hour or so, can lead to trouble as the data in
+    # the cache does not match up with the actual data any more.
+    cache-min-ttl: 300
+
+    # Set the working directory for the program.
+    directory: "/opt/unbound/etc/unbound"
+
+    # RFC 6891. Number  of bytes size to advertise as the EDNS reassembly buffer
+    # size. This is the value put into  datagrams over UDP towards peers.
+    # The actual buffer size is determined by msg-buffer-size (both for TCP and
+    # UDP). Do not set higher than that value.
+    # Default  is  1232 which is the DNS Flag Day 2020 recommendation.
+    # Setting to 512 bypasses even the most stringent path MTU problems, but
+    # is seen as extreme, since the amount of TCP fallback generated is
+    # excessive (probably also for this resolver, consider tuning the outgoing
+    # tcp number).
+    edns-buffer-size: 1232
+
+    # Listen to for queries from clients and answer from this network interface
+    # and port.
+    interface: 0.0.0.0@53
+
+    # Rotates RRSet order in response (the pseudo-random number is taken from
+    # the query ID, for speed and thread safety).
+    rrset-roundrobin: yes
+
+    # Drop user  privileges after  binding the port.
+    username: "_unbound"
+
+    ###########################################################################
+    # LOGGING
+    ###########################################################################
+
+    # Do not print log lines to inform about local zone actions
+    log-local-actions: no
+
+    # Do not print one line per query to the log
+    log-queries: no
+
+    # Do not print one line per reply to the log
+    log-replies: no
+
+    # Do not print log lines that say why queries return SERVFAIL to clients
+    log-servfail: no
+
+    # Further limit logging
+    logfile: /dev/null
+
+    # Only log errors
+    verbosity: 0
+
+    ###########################################################################
+    # PRIVACY SETTINGS
+    ###########################################################################
+
+    # RFC 8198. Use the DNSSEC NSEC chain to synthesize NXDO-MAIN and other
+    # denials, using information from previous NXDO-MAINs answers. In other
+    # words, use cached NSEC records to generate negative answers within a
+    # range and positive answers from wildcards. This increases performance,
+    # decreases latency and resource utilization on both authoritative and
+    # recursive servers, and increases privacy. Also, it may help increase
+    # resilience to certain DoS attacks in some circumstances.
+    aggressive-nsec: yes
+
+    # Extra delay for timeouted UDP ports before they are closed, in msec.
+    # This prevents very delayed answer packets from the upstream (recursive)
+    # servers from bouncing against closed ports and setting off all sort of
+    # close-port counters, with eg. 1500 msec. When timeouts happen you need
+    # extra sockets, it checks the ID and remote IP of packets, and unwanted
+    # packets are added to the unwanted packet counter.
+    delay-close: 10000
+
+    # Prevent the unbound server from forking into the background as a daemon
+    do-daemonize: no
+
+    # Add localhost to the do-not-query-address list.
+    do-not-query-localhost: no
+
+    # Number  of  bytes size of the aggressive negative cache.
+    neg-cache-size: 4M
+
+    # Send minimum amount of information to upstream servers to enhance
+    # privacy (best privacy).
+    qname-minimisation: yes
+
+    ###########################################################################
+    # SECURITY SETTINGS
+    ###########################################################################
+    # Only give access to recursion clients from LAN IPs
+    access-control: 127.0.0.1/32 allow
+    access-control: 192.168.0.0/16 allow
+    access-control: 172.16.0.0/12 allow
+    access-control: 10.0.0.0/8 allow
+    # access-control: fc00::/7 allow
+    # access-control: ::1/128 allow
+
+    # File with trust anchor for  one  zone, which is tracked with RFC5011
+    # probes.
+    auto-trust-anchor-file: "var/root.key"
+
+    # Enable chroot (i.e, change apparent root directory for the current
+    # running process and its children)
+    chroot: "/opt/unbound/etc/unbound"
+
+    # Deny queries of type ANY with an empty response.
+    deny-any: yes
+
+    # Harden against algorithm downgrade when multiple algorithms are
+    # advertised in the DS record.
+    harden-algo-downgrade: yes
+
+    # RFC 8020. returns nxdomain to queries for a name below another name that
+    # is already known to be nxdomain.
+    harden-below-nxdomain: yes
+
+    # Require DNSSEC data for trust-anchored zones, if such data is absent, the
+    # zone becomes bogus. If turned off you run the risk of a downgrade attack
+    # that disables security for a zone.
+    harden-dnssec-stripped: yes
+
+    # Only trust glue if it is within the servers authority.
+    harden-glue: yes
+
+    # Ignore very large queries.
+    harden-large-queries: yes
+
+    # Perform additional queries for infrastructure data to harden the referral
+    # path. Validates the replies if trust anchors are configured and the zones
+    # are signed. This enforces DNSSEC validation on nameserver NS sets and the
+    # nameserver addresses that are encountered on the referral path to the
+    # answer. Experimental option.
+    harden-referral-path: no
+
+    # Ignore very small EDNS buffer sizes from queries.
+    harden-short-bufsize: yes
+
+    # If enabled the HTTP header User-Agent is not set. Use with  caution
+    # as some webserver configurations may reject HTTP requests lacking
+    # this header. If needed, it is better to explicitly set the
+    # the http-user-agent.
+    hide-http-user-agent: no
+
+    # Refuse id.server and hostname.bind queries
+    hide-identity: yes
+
+    # Refuse version.server and version.bind queries
+    hide-version: yes
+
+    # Set the HTTP User-Agent header for outgoing HTTP requests. If
+    # set to "", the default, then the package name  and  version  are
+    #  used.
+    http-user-agent: "DNS"
+
+    # Report this identity rather than the hostname of the server.
+    identity: "DNS"
+
+    # These private network addresses are not allowed to be returned for public
+    # internet names. Any  occurrence of such addresses are removed from DNS
+    # answers. Additionally, the DNSSEC validator may mark the  answers  bogus.
+    # This  protects  against DNS  Rebinding
+    private-address: 10.0.0.0/8
+    private-address: 172.16.0.0/12
+    private-address: 192.168.0.0/16
+    private-address: 169.254.0.0/16
+    # private-address: fd00::/8
+    # private-address: fe80::/10
+    # private-address: ::ffff:0:0/96
+
+    # Enable ratelimiting of queries (per second) sent to nameserver for
+    # performing recursion. More queries are turned away with an error
+    # (servfail). This stops recursive floods (e.g., random query names), but
+    # not spoofed reflection floods. Cached responses are not rate limited by
+    # this setting. Experimental option.
+    ratelimit: 1000
+
+    # Use this certificate bundle for authenticating connections made to
+    # outside peers (e.g., auth-zone urls, DNS over TLS connections).
+    tls-cert-bundle: /etc/ssl/certs/ca-certificates.crt
+
+    # Set the total number of unwanted replies to eep track of in every thread.
+    # When it reaches the threshold, a defensive action of clearing the rrset
+    # and message caches is taken, hopefully flushing away any poison.
+    # Unbound suggests a value of 10 million.
+    unwanted-reply-threshold: 10000
+
+    # Use 0x20-encoded random bits in the query to foil spoof attempts. This
+    # perturbs the lowercase and uppercase of query names sent to authority
+    # servers and checks if the reply still has the correct casing.
+    # This feature is an experimental implementation of draft dns-0x20.
+    # Experimental option.
+    use-caps-for-id: yes
+
+    # Help protect users that rely on this validator for authentication from
+    # potentially bad data in the additional section. Instruct the validator to
+    # remove data from the additional section of secure messages that are not
+    # signed properly. Messages that are insecure, bogus, indeterminate or
+    # unchecked are not affected.
+    val-clean-additional: yes
+
+    ###########################################################################
+    # PERFORMANCE SETTINGS
+    ###########################################################################
+    # https://nlnetlabs.nl/documentation/unbound/howto-optimise/
+    # https://nlnetlabs.nl/news/2019/Feb/05/unbound-1.9.0-released/
+
+    # Number of slabs in the infrastructure cache. Slabs reduce lock contention
+    # by threads. Must be set to a power of 2.
+    infra-cache-slabs: @SLABS@
+
+    # Number of incoming TCP buffers to allocate per thread. Default
+    # is 10. If set to 0, or if do-tcp is "no", no  TCP  queries  from
+    # clients  are  accepted. For larger installations increasing this
+    # value is a good idea.
+    incoming-num-tcp: 10
+
+    # Number of slabs in the key cache. Slabs reduce lock contention by
+    # threads. Must be set to a power of 2. Setting (close) to the number
+    # of cpus is a reasonable guess.
+    key-cache-slabs: @SLABS@
+
+    # Number  of  bytes  size  of  the  message  cache.
+    # Unbound recommendation is to Use roughly twice as much rrset cache memory
+    # as you use msg cache memory.
+    msg-cache-size: @MSG_CACHE_SIZE@
+
+    # Number of slabs in the message cache. Slabs reduce lock contention by
+    # threads. Must be set to a power of 2. Setting (close) to the number of
+    # cpus is a reasonable guess.
+    msg-cache-slabs: @SLABS@
+
+    # The number of queries that every thread will service simultaneously. If
+    # more queries arrive that need servicing, and no queries can be jostled
+    # out (see jostle-timeout), then the queries are dropped.
+    # This is best set at half the number of the outgoing-range.
+    # This Unbound instance was compiled with libevent so it can efficiently
+    # use more than 1024 file descriptors.
+    num-queries-per-thread: 4096
+
+    # The number of threads to create to serve clients.
+    # This is set dynamically at run time to effectively use available CPUs
+    # resources
+    num-threads: @THREADS@
+
+    # Number of ports to open. This number of file descriptors can be opened
+    # per thread.
+    # This Unbound instance was compiled with libevent so it can efficiently
+    # use more than 1024 file descriptors.
+    outgoing-range: 8192
+
+    # Number of bytes size of the RRset cache.
+    # Use roughly twice as much rrset cache memory as msg cache memory
+    rrset-cache-size: @RR_CACHE_SIZE@
+
+    # Number of slabs in the RRset cache. Slabs reduce lock contention by
+    # threads. Must be set to a power of 2.
+    rrset-cache-slabs: @SLABS@
+
+    # Do no insert authority/additional sections into response messages when
+    # those sections are not required. This reduces response size
+    # significantly, and may avoid TCP fallback for some responses. This may
+    # cause a slight speedup.
+    minimal-responses: yes
+
+    # # Fetch the DNSKEYs earlier in the validation process, when a DS record
+    # is encountered. This lowers the latency of requests at the expense of
+    # little more CPU usage.
+    prefetch: yes
+
+    # Fetch the DNSKEYs earlier in the validation process, when a DS record is
+    # encountered. This lowers the latency of requests at the expense of little
+    # more CPU usage.
+    prefetch-key: yes
+
+    # Have unbound attempt to serve old responses from cache with a TTL of 0 in
+    # the response without waiting for the actual resolution to finish. The
+    # actual resolution answer ends up in the cache later on.
+    serve-expired: yes
+
+    # Open dedicated listening sockets for incoming queries for each thread and
+    # try to set the SO_REUSEPORT socket option on each socket. May distribute
+    # incoming queries to threads more evenly.
+    so-reuseport: yes
+
+    ###########################################################################
+    # LOCAL ZONE
+    ###########################################################################
+
+    # Include file for local-data and local-data-ptr
+    include: /opt/unbound/etc/unbound/a-records.conf
+    include: /opt/unbound/etc/unbound/srv-records.conf
+
+    ###########################################################################
+    # FORWARD ZONE
+    ###########################################################################
+
+    include: /opt/unbound/etc/unbound/forward-records.conf
+
+    ###########################################################################
+    # WILDCARD INCLUDE
+    ###########################################################################
+    #include: "/opt/unbound/etc/unbound/*.conf"
+
+remote-control:
+    control-enable: no
+EOT
+fi
+
+mkdir -p /opt/unbound/etc/unbound/dev && \
+cp -a /dev/random /dev/urandom /dev/null /opt/unbound/etc/unbound/dev/
+
+mkdir -p -m 700 /opt/unbound/etc/unbound/var && \
+chown _unbound:_unbound /opt/unbound/etc/unbound/var && \
+/opt/unbound/sbin/unbound-anchor -a /opt/unbound/etc/unbound/var/root.key
+
+exec /opt/unbound/sbin/unbound -d -c /opt/unbound/etc/unbound/unbound.conf


### PR DESCRIPTION
this just bumps the associated openssl release and adds support for the latest unbound release (1.23.1) which addresses a CVE.

this also removes the extra call for `linux-x32` in the openssl build process.  i'm also building for arm64 and armv7 so having openssl autodetect as appropriate seemed like a reasonable change to make.  no observed issues with this build.